### PR TITLE
Slash menu and formatting toolbar

### DIFF
--- a/packages/core/src/extensions/Blocks/api/inlineContentTypes.ts
+++ b/packages/core/src/extensions/Blocks/api/inlineContentTypes.ts
@@ -1,17 +1,19 @@
 export type Styles = {
-  bold?: true;
-  italic?: true;
-  strikethrough?: true;
-  inlineImage?: true;
-  inlineFile?: true;
-  code?: true;
+  task?: boolean;
+  checkbox?: boolean;
+  bold?: boolean;
+  italic?: boolean;
+  strikethrough?: boolean;
+  inlineImage?: boolean;
+  inlineFile?: boolean;
+  code?: boolean;
   textColor?: string;
   backgroundColor?: string;
-  highlighted?: true;
-  underlined?: true;
-  hashtag?: true;
-  wikilink?: true;
-  datelink?: true;
+  highlighted?: boolean;
+  underlined?: boolean;
+  hashtag?: boolean;
+  wikilink?: boolean;
+  datelink?: boolean;
 };
 
 export type ContentAttributes = {
@@ -20,7 +22,7 @@ export type ContentAttributes = {
 };
 
 export type ToggledStyle = {
-  [K in keyof Styles]-?: Required<Styles>[K] extends true ? K : never;
+  [K in keyof Styles]-?: Required<Styles>[K] extends boolean ? K : never;
 }[keyof Styles];
 
 export type ColorStyle = {

--- a/packages/core/src/extensions/SlashMenu/defaultSlashMenuItems.tsx
+++ b/packages/core/src/extensions/SlashMenu/defaultSlashMenuItems.tsx
@@ -26,6 +26,46 @@ function insertOrUpdateBlock<BSchema extends DefaultBlockSchema>(
  * An array containing commands for creating all default blocks.
  */
 export const defaultSlashMenuItems = [
+  // Command for creating a task item
+  new BaseSlashMenuItem<DefaultBlockSchema>(
+    "Task",
+    (editor) =>
+      insertOrUpdateBlock(editor, {
+        type: "taskListItem",
+      }),
+    ["task", "taskList", "task list"]
+  ),
+
+  // Command for creating a task item
+  new BaseSlashMenuItem<DefaultBlockSchema>(
+    "Checklist",
+    (editor) =>
+      insertOrUpdateBlock(editor, {
+        type: "checkListItem",
+      }),
+    ["check", "checkbox", "checkList", "check list"]
+  ),
+
+  // Command for creating a bullet list
+  new BaseSlashMenuItem<DefaultBlockSchema>(
+    "Bullet Point",
+    (editor) =>
+      insertOrUpdateBlock(editor, {
+        type: "bulletListItem",
+      }),
+    ["ul", "list", "bulletPoint", "bullet point"]
+  ),
+
+  // Command for creating an ordered list
+  new BaseSlashMenuItem<DefaultBlockSchema>(
+    "Numbered List",
+    (editor) =>
+      insertOrUpdateBlock(editor, {
+        type: "numberedListItem",
+      }),
+    ["li", "numberedlist", "numbered list"]
+  ),
+
   // Command for creating a level 1 heading
   new BaseSlashMenuItem<DefaultBlockSchema>(
     "Heading",
@@ -59,35 +99,15 @@ export const defaultSlashMenuItems = [
     ["h3", "heading3", "subheading"]
   ),
 
-  // Command for creating an ordered list
-  new BaseSlashMenuItem<DefaultBlockSchema>(
-    "Numbered List",
-    (editor) =>
-      insertOrUpdateBlock(editor, {
-        type: "numberedListItem",
-      }),
-    ["li", "list", "numberedlist", "numbered list"]
-  ),
-
-  // Command for creating a bullet list
-  new BaseSlashMenuItem<DefaultBlockSchema>(
-    "Bullet List",
-    (editor) =>
-      insertOrUpdateBlock(editor, {
-        type: "bulletListItem",
-      }),
-    ["ul", "list", "bulletlist", "bullet list"]
-  ),
-
   // Command for creating a paragraph (pretty useless)
-  new BaseSlashMenuItem<DefaultBlockSchema>(
-    "Paragraph",
-    (editor) =>
-      insertOrUpdateBlock(editor, {
-        type: "paragraph",
-      }),
-    ["p"]
-  ),
+  // new BaseSlashMenuItem<DefaultBlockSchema>(
+  //   "Paragraph",
+  //   (editor) =>
+  //     insertOrUpdateBlock(editor, {
+  //       type: "paragraph",
+  //     }),
+  //   ["p"]
+  // ),
 
   //     replaceRangeWithNode(editor, range, node);
 

--- a/packages/react/src/BlockNoteTheme.ts
+++ b/packages/react/src/BlockNoteTheme.ts
@@ -78,6 +78,17 @@ export const getBlockNoteTheme = (
     ? blockNoteColorScheme[5]
     : blockNoteColorScheme[3];
 
+    //TODO: Implement NotePlan themes for the approach used above for BlockNote
+  const slashMenuitemColor = "#EADACE";
+  const backgroundSlashMenuColor = "#F2F4F5";
+  const slashMenuIconColor = "#A4A5A7";
+  const slashMenuItemTextColor = "#363638";
+  const slashMenuLabelTextColor = "#858689";
+  const slashMenuBorderColor = "#D8D9DC";
+  const toolbarBackground = "rgb(254 215 170)";
+  const toolbarColor = "rgb(55, 65, 81)";
+
+
   return {
     activeStyles: {
       // Removes button press effect.
@@ -127,19 +138,20 @@ export const getBlockNoteTheme = (
       Menu: {
         styles: () => ({
           dropdown: {
-            backgroundColor: primaryBackground,
+            font: "var(--fa-font-solid)",
+            backgroundColor: backgroundSlashMenuColor,
             border: border,
             borderRadius: "6px",
             boxShadow: boxShadow,
             color: primaryText,
             padding: "2px",
             ".mantine-Menu-item": {
-              backgroundColor: primaryBackground,
+              backgroundColor: slashMenuitemColor,
               border: "none",
               color: primaryText,
             },
             ".mantine-Menu-item[data-hovered]": {
-              backgroundColor: hoveredBackground,
+              backgroundColor: slashMenuitemColor,
               border: "none",
               color: hoveredText,
             },
@@ -205,26 +217,25 @@ export const getBlockNoteTheme = (
             borderRadius: "6px",
             flexWrap: "nowrap",
             gap: "2px",
-            padding: "2px",
+            padding: "5px 8px 6px 8px",
             width: "fit-content",
             // Button (including dropdown target)
             ".mantine-UnstyledButton-root": {
               backgroundColor: primaryBackground,
               border: "none",
               borderRadius: "4px",
-              color: primaryText,
+              color: toolbarColor,
+              fontWeight: 600,
             },
             // Hovered button
             ".mantine-UnstyledButton-root:hover": {
-              backgroundColor: hoveredBackground,
+              backgroundColor: toolbarBackground,
               border: "none",
-              color: hoveredText,
             },
             // Selected button
             ".mantine-UnstyledButton-root[data-selected]": {
-              backgroundColor: selectedBackground,
+              backgroundColor: toolbarBackground,
               border: "none",
-              color: selectedText,
             },
             // Disabled button
             ".mantine-UnstyledButton-root[data-disabled]": {
@@ -252,15 +263,15 @@ export const getBlockNoteTheme = (
       Tooltip: {
         styles: () => ({
           root: {
-            backgroundColor: primaryBackground,
+            backgroundColor: "black",
             border: border,
             borderRadius: "6px",
             boxShadow: boxShadow,
-            color: primaryText,
+            color: "white",
             padding: "4px 10px",
             textAlign: "center",
             "div ~ div": {
-              color: secondaryText,
+              color: "white",
             },
           },
         }),
@@ -269,26 +280,58 @@ export const getBlockNoteTheme = (
         styles: () => ({
           root: {
             position: "relative",
+            background: backgroundSlashMenuColor,
+            padding: "14px 0",
+            border: `1px solid ${slashMenuBorderColor}`,
+            outline: "none",
+            maxHeight: 360,
+            minWidth: 450,
+            width: 450,
+            overflow: "hidden",
             ".mantine-Menu-item": {
               // Icon
+              height: 26,
+              padding: 0,
+              width: "100%",
+              display: "flex",
+              color: slashMenuItemTextColor,
+              backgroundColor: "transparent",
+              alignItems: "flex-end",
+              cursor: "pointer",
+              fontWeight: 400,
+              paddingBottom: 2,
+              fontSize: 13,
+              ":hover,:active": {
+                backgroundColor: slashMenuitemColor,
+              },
               ".mantine-Menu-itemIcon": {
-                backgroundColor: secondaryBackground,
+                backgroundColor: "transparent",
                 borderRadius: "4px",
-                color: primaryText,
-                padding: "8px",
+                color: slashMenuIconColor,
+                width: 47,
+                boxSizing: "content-box",
+                fontSize: 15,
+                marginRight: 6,
+                marginBottom: 1,
               },
               // Text
               ".mantine-Menu-itemLabel": {
-                paddingRight: "16px",
                 ".mantine-Stack-root": {
                   gap: "0",
                 },
               },
-              // Badge (keyboard shortcut)
+              // Badge (markdown hint)
               ".mantine-Menu-itemRightSection": {
+                marginLeft: "auto",
+                textTransform: "lowercase",
                 ".mantine-Badge-root": {
-                  backgroundColor: secondaryBackground,
-                  color: primaryText,
+                  backgroundColor: "transparent",
+                  color: slashMenuLabelTextColor,
+                  fontSize: 10,
+                  fontWeight: 400,
+                  textTransform: "none",
+                  marginBottom: 3,
+                  marginRight: 19,
                 },
               },
             },

--- a/packages/react/src/FormattingToolbar/components/DefaultButtons/CreateLinkButton.tsx
+++ b/packages/react/src/FormattingToolbar/components/DefaultButtons/CreateLinkButton.tsx
@@ -1,9 +1,9 @@
 import { useCallback } from "react";
 import { BlockNoteEditor, BlockSchema } from "@blocknote/core";
-import { RiLink } from "react-icons/ri";
 import LinkToolbarButton from "../LinkToolbarButton";
 import { formatKeyboardShortcut } from "../../../utils";
-
+import iconsData from "../FontIcons";
+const { link } = iconsData;
 export const CreateLinkButton = <BSchema extends BlockSchema>(props: {
   editor: BlockNoteEditor<BSchema>;
 }) => {
@@ -20,7 +20,7 @@ export const CreateLinkButton = <BSchema extends BlockSchema>(props: {
       isSelected={!!props.editor.getSelectedLinkUrl()}
       mainTooltip="Link"
       secondaryTooltip={formatKeyboardShortcut("Mod+K")}
-      icon={RiLink}
+      icon={link}
       hyperlinkIsActive={!!props.editor.getSelectedLinkUrl()}
       activeHyperlinkUrl={props.editor.getSelectedLinkUrl() || ""}
       activeHyperlinkText={props.editor.getSelectedText()}

--- a/packages/react/src/FormattingToolbar/components/DefaultButtons/TextAlignButton.tsx
+++ b/packages/react/src/FormattingToolbar/components/DefaultButtons/TextAlignButton.tsx
@@ -6,21 +6,17 @@ import {
 } from "@blocknote/core";
 import { useCallback, useMemo } from "react";
 import { IconType } from "react-icons";
-import {
-  RiAlignCenter,
-  RiAlignJustify,
-  RiAlignLeft,
-  RiAlignRight,
-} from "react-icons/ri";
 import { ToolbarButton } from "../../../SharedComponents/Toolbar/components/ToolbarButton";
+import iconsData from "../FontIcons";
+const { left, center, right, justify } = iconsData;
 
 type TextAlignment = DefaultProps["textAlignment"]["values"][number];
 
 const icons: Record<TextAlignment, IconType> = {
-  left: RiAlignLeft,
-  center: RiAlignCenter,
-  right: RiAlignRight,
-  justify: RiAlignJustify,
+  left,
+  center,
+  right,
+  justify,
 };
 
 export const TextAlignButton = <BSchema extends BlockSchema>(props: {

--- a/packages/react/src/FormattingToolbar/components/DefaultButtons/ToggledStyleButton.tsx
+++ b/packages/react/src/FormattingToolbar/components/DefaultButtons/ToggledStyleButton.tsx
@@ -1,18 +1,24 @@
 import { ToolbarButton } from "../../../SharedComponents/Toolbar/components/ToolbarButton";
 import { formatKeyboardShortcut } from "../../../utils";
-import {
-  RiBold,
-  RiCodeFill,
-  RiItalic,
-  RiStrikethrough,
-  RiUnderline,
-  RiHashtag,
-  RiLink,
-} from "react-icons/ri";
 import { BlockNoteEditor, BlockSchema, ToggledStyle } from "@blocknote/core";
 import { IconType } from "react-icons";
+import iconsData from "../FontIcons";
+const {
+  bold,
+  link,
+  italic,
+  underlined,
+  strikethrough,
+  highlighted,
+  code,
+  hashtag,
+  task,
+  checkbox,
+} = iconsData;
 
 const shortcuts: Record<ToggledStyle, string> = {
+  task: "",
+  checkbox: "",
   bold: "Mod+B",
   italic: "Mod+I",
   underlined: "Mod+U",
@@ -27,17 +33,19 @@ const shortcuts: Record<ToggledStyle, string> = {
 };
 
 const icons: Record<ToggledStyle, IconType> = {
-  bold: RiBold,
-  italic: RiItalic,
-  underlined: RiUnderline,
-  strikethrough: RiStrikethrough,
-  highlighted: RiCodeFill,
-  code: RiCodeFill,
-  hashtag: RiHashtag,
-  wikilink: RiLink,
-  datelink: RiLink,
-  inlineFile: RiLink,
-  inlineImage: RiLink,
+  task,
+  checkbox,
+  bold,
+  italic,
+  underlined,
+  strikethrough,
+  highlighted,
+  code,
+  hashtag,
+  wikilink: link,
+  datelink: link,
+  inlineFile: link,
+  inlineImage: link,
 };
 
 export const ToggledStyleButton = <BSchema extends BlockSchema>(props: {

--- a/packages/react/src/FormattingToolbar/components/FontIcons.tsx
+++ b/packages/react/src/FormattingToolbar/components/FontIcons.tsx
@@ -1,0 +1,27 @@
+const getIcon = (
+  name: string | number,
+  type: string = "solid",
+  family: string = ""
+) => <i className={`fa-${type} fa-${name} ${family}`}></i>;
+
+const iconsData = {
+  task: () => getIcon("circle-check", "regular"),
+  checkbox: () => getIcon("square-check", "regular"),
+  bold: () => getIcon("bold"),
+  italic: () => getIcon("italic"),
+  underlined: () => getIcon("underline"),
+  strikethrough: () => getIcon("strikethrough"),
+  highlighted: () => getIcon("highlighter", "regular", "sharp"),
+  hashtag: () => getIcon("hashtag"),
+  code: () => getIcon("code-simple"),
+  link: () => getIcon("link"),
+  getIcon,
+  bullet: () => getIcon("circle-small"),
+  heading: () => getIcon("heading"),
+  numList: () => getIcon("list-ol"),
+  left: () => getIcon("align-left"),
+  center: () => getIcon("align-center"),
+  right: () => getIcon("align-right"),
+  justify: () => getIcon("align-justify"),
+};
+export default iconsData;

--- a/packages/react/src/FormattingToolbar/components/FormattingToolbar.tsx
+++ b/packages/react/src/FormattingToolbar/components/FormattingToolbar.tsx
@@ -1,39 +1,23 @@
 import { BlockNoteEditor, BlockSchema } from "@blocknote/core";
 import { Toolbar } from "../../SharedComponents/Toolbar/components/Toolbar";
-import { ColorStyleButton } from "./DefaultButtons/ColorStyleButton";
 import { CreateLinkButton } from "./DefaultButtons/CreateLinkButton";
-import {
-  NestBlockButton,
-  UnnestBlockButton,
-} from "./DefaultButtons/NestBlockButtons";
-import { TextAlignButton } from "./DefaultButtons/TextAlignButton";
 import { ToggledStyleButton } from "./DefaultButtons/ToggledStyleButton";
-import { BlockTypeDropdown } from "./DefaultDropdowns/BlockTypeDropdown";
 
 export const FormattingToolbar = <BSchema extends BlockSchema>(props: {
   editor: BlockNoteEditor<BSchema>;
 }) => {
   return (
     <Toolbar>
-      <BlockTypeDropdown {...props} />
-
       <ToggledStyleButton editor={props.editor} toggledStyle={"bold"} />
       <ToggledStyleButton editor={props.editor} toggledStyle={"italic"} />
       <ToggledStyleButton editor={props.editor} toggledStyle={"underlined"} />
+      <ToggledStyleButton editor={props.editor} toggledStyle={"highlighted"} />
+
       <ToggledStyleButton
         editor={props.editor}
         toggledStyle={"strikethrough"}
       />
-
-      <TextAlignButton editor={props.editor as any} textAlignment={"left"} />
-      <TextAlignButton editor={props.editor as any} textAlignment={"center"} />
-      <TextAlignButton editor={props.editor as any} textAlignment={"right"} />
-
-      <ColorStyleButton editor={props.editor} />
-
-      <NestBlockButton editor={props.editor} />
-      <UnnestBlockButton editor={props.editor} />
-
+      <ToggledStyleButton editor={props.editor} toggledStyle={"code"} />
       <CreateLinkButton editor={props.editor} />
     </Toolbar>
   );

--- a/packages/react/src/SharedComponents/Tooltip/components/TooltipContent.tsx
+++ b/packages/react/src/SharedComponents/Tooltip/components/TooltipContent.tsx
@@ -3,14 +3,19 @@ import { createStyles, Stack, Text } from "@mantine/core";
 export const TooltipContent = (props: {
   mainTooltip: string;
   secondaryTooltip?: string;
+  showMainTooltip?: boolean;
 }) => {
   const { classes } = createStyles({ root: {} })(undefined, {
     name: "Tooltip",
   });
-
+  if (!props.secondaryTooltip) {
+    return null;
+  }
   return (
     <Stack spacing={0} className={classes.root}>
-      <Text size={"sm"}>{props.mainTooltip}</Text>
+      {props.showMainTooltip ? (
+        <Text size={"sm"}>{props.mainTooltip}</Text>
+      ) : null}
       {props.secondaryTooltip && (
         <Text size={"xs"}>{props.secondaryTooltip}</Text>
       )}

--- a/packages/react/src/SlashMenu/ReactSlashMenuItem.ts
+++ b/packages/react/src/SlashMenu/ReactSlashMenuItem.ts
@@ -14,7 +14,8 @@ export class ReactSlashMenuItem<
     public readonly group: string,
     public readonly icon: JSX.Element,
     public readonly hint?: string,
-    public readonly shortcut?: string
+    public readonly shortcut?: string,
+    public readonly markdownHint?: string
   ) {
     super(name, execute, aliases);
   }

--- a/packages/react/src/SlashMenu/components/SlashMenu.tsx
+++ b/packages/react/src/SlashMenu/components/SlashMenu.tsx
@@ -22,18 +22,14 @@ export function SlashMenu<BSchema extends BlockSchema>(
   const groups = _.groupBy(props.items, (i) => i.group);
 
   _.forEach(groups, (el) => {
-    renderedItems.push(
-      <Menu.Label key={el[0].group}>{el[0].group}</Menu.Label>
-    );
-
     for (const item of el) {
       renderedItems.push(
         <SlashMenuItem
           key={item.name}
           name={item.name}
-          icon={item.icon}
+          icon={item?.icon}
           hint={item.hint}
-          shortcut={item.shortcut}
+          shortcut={item?.markdownHint ?? ""}
           isSelected={props.keyboardHoveredItemIndex === index}
           set={() => props.itemCallback(item)}
         />
@@ -51,6 +47,7 @@ export function SlashMenu<BSchema extends BlockSchema>(
        * close due to trigger="hover".
        */
       defaultOpened={true}
+      unstyled
       trigger={"hover"}
       closeDelay={10000000}>
       <Menu.Dropdown className={classes.root}>

--- a/packages/react/src/SlashMenu/components/SlashMenuItem.tsx
+++ b/packages/react/src/SlashMenu/components/SlashMenuItem.tsx
@@ -70,10 +70,7 @@ export function SlashMenuItem(props: SlashMenuItemProps) {
       }>
       <Stack>
         {/*Might need separate classes.*/}
-        <Text size={14} weight={500}>
-          {props.name}
-        </Text>
-        <Text size={10}>{props.hint}</Text>
+        <Text title={props.hint}>{props.name}</Text>
       </Stack>
     </Menu.Item>
   );

--- a/packages/react/src/SlashMenu/defaultReactSlashMenuItems.tsx
+++ b/packages/react/src/SlashMenu/defaultReactSlashMenuItems.tsx
@@ -3,16 +3,17 @@ import {
   DefaultBlockSchema,
   defaultSlashMenuItems,
 } from "@blocknote/core";
-import {
-  RiH1,
-  RiH2,
-  RiH3,
-  RiListOrdered,
-  RiListUnordered,
-  RiText,
-} from "react-icons/ri";
 import { formatKeyboardShortcut } from "../utils";
 import { ReactSlashMenuItem } from "./ReactSlashMenuItem";
+import iconsData from "../FormattingToolbar/components/FontIcons";
+const { heading, task, numList, bullet, checkbox, getIcon } = iconsData;
+
+const FullHeadingIcon = ({ order }: { order: number }) => (
+  <>
+    {heading()}
+    {getIcon(order)}
+  </>
+);
 const extraFields: Record<
   string,
   Omit<
@@ -20,41 +21,54 @@ const extraFields: Record<
     keyof BaseSlashMenuItem<DefaultBlockSchema>
   >
 > = {
+  Task: {
+    group: "Basic blocks",
+    icon: task(),
+    markdownHint: "* task",
+    hint: "Used to display a task list",
+    shortcut: "",
+  },
+  Checklist: {
+    group: "Basic blocks",
+    icon: checkbox(),
+    markdownHint: "+ checklist",
+    hint: "Used to display a checkbox list",
+    shortcut: "",
+  },
+  "Bullet Point": {
+    group: "Basic blocks",
+    icon: bullet(),
+    markdownHint: "- bullet",
+    hint: "Used to display an unordered list",
+    shortcut: formatKeyboardShortcut("Mod-Alt-9"),
+  },
+  "Numbered List": {
+    group: "Basic blocks",
+    icon: numList(),
+    markdownHint: ". number",
+    hint: "Used to display a numbered list",
+    shortcut: formatKeyboardShortcut("Mod-Alt-7"),
+  },
   Heading: {
     group: "Headings",
-    icon: <RiH1 size={18} />,
+    icon: <FullHeadingIcon order={1} />,
+    markdownHint: "# H1",
     hint: "Used for a top-level heading",
     shortcut: formatKeyboardShortcut("Mod-Alt-1"),
   },
   "Heading 2": {
     group: "Headings",
-    icon: <RiH2 size={18} />,
+    icon: <FullHeadingIcon order={2} />,
+    markdownHint: "## H2",
     hint: "Used for key sections",
     shortcut: formatKeyboardShortcut("Mod-Alt-2"),
   },
   "Heading 3": {
     group: "Headings",
-    icon: <RiH3 size={18} />,
+    icon: <FullHeadingIcon order={3} />,
+    markdownHint: "### H3",
     hint: "Used for subsections and group headings",
     shortcut: formatKeyboardShortcut("Mod-Alt-3"),
-  },
-  "Numbered List": {
-    group: "Basic blocks",
-    icon: <RiListOrdered size={18} />,
-    hint: "Used to display a numbered list",
-    shortcut: formatKeyboardShortcut("Mod-Alt-7"),
-  },
-  "Bullet List": {
-    group: "Basic blocks",
-    icon: <RiListUnordered size={18} />,
-    hint: "Used to display an unordered list",
-    shortcut: formatKeyboardShortcut("Mod-Alt-9"),
-  },
-  Paragraph: {
-    group: "Basic blocks",
-    icon: <RiText size={18} />,
-    hint: "Used for the body of your document",
-    shortcut: formatKeyboardShortcut("Mod-Alt-0"),
   },
 };
 
@@ -67,6 +81,7 @@ export const defaultReactSlashMenuItems = defaultSlashMenuItems.map(
       extraFields[item.name].group,
       extraFields[item.name].icon,
       extraFields[item.name].hint,
-      extraFields[item.name].shortcut
+      extraFields[item.name].shortcut,
+      extraFields[item.name].markdownHint
     )
 );


### PR DESCRIPTION
Update the formatting toolbar in BlockNote to resemble the current toolbar and

Adapt the slash/+ menu to look like in NotePlan native with the same items (whatever is available at the moment)